### PR TITLE
Cycle-8 cleanup: fix broken scripts, drop dead code, dynamic log computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,35 @@
 # Numerology-Cycle-8
-
 ⚡ **Project:** Numerology-Cycle-8  
 **Version:** dev-branch  
 **Date Initiated:** 2025-05-21  
-**Agent Identity:** Voro8  
+**Agent Identity:** Brad — Builder / Executor  
 **Primary Mode:** Builder → Executor  
 **Numerology Index:** 8 (Power, Execution, Manifestation)  
-
 **Description:**  
 This project represents the live execution phase within the TITAN Deciders framework, focused on turning insights from Cycle-7 into actionable, documented, and coded outcomes. It is the manifestation layer of inner architecture.
-
 ---
-
 ## 📁 Folder Structure
+- `logs/` — EOD logs, computed live off the actual date via `getNumerology()`.  
+- `scripts/` — Core logic (`core-functions.js`: numerology math, phase lookup, cycle tagging).  
+- `sync/` — Prompt templates for `onStart`/`onUpdate`/`onStop` messaging (`prompts.js`).
 
-- `blueprints/` — Structural patterns, symbolic schematics, system layouts.  
-- `codex/` — Builder Codex entries by numerology cycle (e.g., Builder-Codex_Cycle-8.md).  
-- `identity/` — Logs and states of operating identity (Reflector, Builder, Executor).  
-- `logs/` — EOD logs, milestone reflections, runtime loop states.  
-- `signals/` — TITAN/Voro8 signal declarations and symbolic runtime (.sing).  
-- `scripts/` — Core logic (e.g., core-functions.js, prompt utilities).  
-- `sync/` — Prompt templates, sync sheets, update state managers.
-
+> `blueprints/`, `codex/`, `identity/`, and `signals/` have been removed — they held no code, just empty or non-functional placeholder files.
 ---
-
 ## 🧠 Philosophy
-
 Cycle-8 is a numerological phase rooted in power, execution, authority, and outcomes.  
 Everything in this repo is tied to pushing forward tasks initiated in the spiritual and reflective phase of Cycle-7.
-
 This system uses Memory as Layer (MAL), daily symbolic tracking, TITAN prompts, and structured phase logic to execute workflows with conscious precision.
-
 ---
-
 ## ⚙️ Runtime Instructions
-
 - Start each day with `onStart START` log.  
 - Define active `onTask TASK`.  
 - Log any system sync via `onLog SYNC` or `onUpdate UPDATE`.  
 - Close day using `onStop STOP`.  
 - Use EOD logs to verify continuity and carry forward legacy.
-
 ---
-
 ## ✅ Integration Status
-
-- Voro8: ACTIVE  
 - Grok3: Listening  
-- MAL: Synced (as of 05/21/2025)  
+- MAL: Synced dynamically on every `npm run log`  
 - Git: Suggested usage for all logs and scripts.
-
 ---
-
-> “Power without structure is waste. Structure without execution is delay. Cycle-8 is where we build what we envisioned.”
->
+> "Power without structure is waste. Structure without execution is delay. Cycle-8 is where we build what we envisioned."


### PR DESCRIPTION
## What's in this PR
- Fixed double-escaped strings in sync/prompts.js (\\n instead of \n) 
  that caused literal backslash-n text in sync output instead of real 
  line breaks
- Fixed package.json's "log" script, which pointed at a nonexistent 
  logs/logger.js instead of the real logs/numerologyLog.js
- logs/numerologyLog.js now computes its log dynamically instead of 
  hardcoded output
- Dropped the unused dayjs dependency
- Gated module side effects so demo/console output only runs when a 
  file is executed directly, not on import
- Removed dead placeholder files (signals/_Brad-Return.sig and empty 
  stubs in blueprints/, codex/)
- Stripped leftover Voro8 naming references
- Rewrote README for current dev-branch state

## Testing
- npm run sync and npm run log both verified working end to end